### PR TITLE
Clarified complex modification configuration when using a custom .json in assets/complex_modifications

### DIFF
--- a/sites/karabiner-elements/content/en/docs/json/_index.md
+++ b/sites/karabiner-elements/content/en/docs/json/_index.md
@@ -1,5 +1,5 @@
 ---
-title: 'karabiner.json Reference Manual'
+title: 'Karabiner Configuration Reference Manual'
 weight: 9000
 simple_list: true
 exclude_search: true

--- a/sites/karabiner-elements/content/en/docs/json/location/index.md
+++ b/sites/karabiner-elements/content/en/docs/json/location/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'File location'
+title: 'File locations'
 weight: 100
 ---
 

--- a/sites/karabiner-elements/content/en/docs/json/root-data-structure/index.md
+++ b/sites/karabiner-elements/content/en/docs/json/root-data-structure/index.md
@@ -139,3 +139,86 @@ Karabiner-Elements does not allow you including comments (`// ...` or `/* ... */
     }
 }
 ```
+
+## custom .json file in ~/config/karabiner/assets/complex_modifications
+
+Note: Adding a custom .json file allows for enabling and disabling rules/complex modifications through the UI.
+
+```json
+{
+    "title": "Title for the list of rules/complex modifications."
+    "rules": [
+        {
+            "description": "This description is shown in Preferences.",
+            "manipulators": [
+                {
+                    "type": "basic",
+
+                    "from": from event definition,
+
+                    "to": [
+                        to event definition,
+                        to event definition,
+                        ...
+                    ],
+
+                    "to_if_alone": [
+                        to event definition,
+                        to event definition,
+                        ...
+                    ],
+
+                    "to_if_held_down": [
+                        to event definition,
+                        to event definition,
+                        ...
+                    ],
+
+                    "to_after_key_up": [
+                        to event definition,
+                        to event definition,
+                        ...
+                    ],
+
+                    "to_delayed_action": {
+                        "to_if_invoked": [
+                            to event definition,
+                            to event definition,
+                            ...
+                        ],
+                        "to_if_canceled": [
+                            to event definition,
+                            to event definition,
+                            ...
+                        ]
+                    },
+
+                    "conditions": [
+                        condition definition,
+                        condition definition,
+                        ...
+                    ],
+
+                    "parameters": {
+                        ...
+                    },
+
+                    "description": "Optional description for human"
+                },
+                {
+                    "type": "basic",
+                    ...
+                },
+                ...
+            ]
+        },
+        {
+            "description": "...",
+            "manipulators": [
+                ...
+            ]
+        },
+        ...
+    ]
+}
+```


### PR DESCRIPTION
Based on this thread, https://github.com/pqrs-org/Karabiner-Elements/issues/1225, I've made the following changes to clarify how to use a custom .json file in ~/config/karabiner/assets/complex_modifications.