### PR TITLE
Fix typo on karabiner-elements index.html

### DIFF
--- a/sites/karabiner-elements/public/index.html
+++ b/sites/karabiner-elements/public/index.html
@@ -355,7 +355,7 @@ if (!doNotTrack) {
     <i class="fas fa-palette"></i>
   </div>
   <h4 class="h3">Flexible</h4>
-  <p class="mb-0"><p>You can write your own rules if you want to modify existence rules or create new rules from scratch.</p>
+  <p class="mb-0"><p>You can write your own rules if you want to modify existing rules or create new rules from scratch.</p>
 </p>
   <p><a href="docs/json/">Read more …</a></p>
 </div>


### PR DESCRIPTION
When looking the homepage for karabiner-elements I noticed this small typo/grammatical error.