### PR TITLE
fix: "This the multi-page" -> "This is the multi-page"

### DIFF
--- a/themes/docsy/i18n/en.toml
+++ b/themes/docsy/i18n/en.toml
@@ -54,7 +54,7 @@ other = "less than a minute"
 
 # Print support
 [print_printable_section]
-other = "This the multi-page printable view of this section."
+other = "This is the multi-page printable view of this section."
 [print_click_to_print]
 other = "Click here to print"
 [print_show_regular]


### PR DESCRIPTION
Hi! :wave:

I stumbled upon a missing word in https://kubernetes.io/docs/reference/using-api/_print/, so I Googled the exact phrasing, and that took me to this repo.

I don't know this project at all, so I don't know if there are tests that need updating or anything like that, but I figured I'd send a PR anyway :smile: 