### PR TITLE
Compatibility with Logitech Logi Options+

### DIFF
--- a/sites/karabiner-elements/content/en/docs/help/troubleshooting/logitech-logi-options-plus-compatibility/index.md
+++ b/sites/karabiner-elements/content/en/docs/help/troubleshooting/logitech-logi-options-plus-compatibility/index.md
@@ -1,0 +1,14 @@
+---
+title: 'Compatibility with Logitech Logi Options+: Fn keys'
+weight: 1000
+---
+
+This was discovered when using an MX Keys keyboard with the “Logi Options+” software.  While Karabiner Elements is running, the Logitech specific function keys (such as `Fn-esc` to toggle between function keys and media keys and `f1`, `f2`, `f3` to switch between inputs) are not recognized.
+
+The solution is to edit `karabiner.json` such that the `"fn_function_keys"` array is empty:
+
+```json
+    "fn_function_keys": []
+```
+
+Credit: https://github.com/pqrs-org/Karabiner-Elements/issues/1450#issuecomment-1013932206


### PR DESCRIPTION
Explain what to do when the Logitech software Logi Options+ no longer
recognizes Logitech specific function keys, such as fn-esc to toggle
between F keys as function keys and F keys as media keys.