### PR TITLE
add missing Gravis in Karabiner-Element docu

### DIFF
--- a/sites/karabiner-elements/content/en/docs/json/complex-modifications-manipulator-definition/conditions/device/index.md
+++ b/sites/karabiner-elements/content/en/docs/json/complex-modifications-manipulator-definition/conditions/device/index.md
@@ -64,7 +64,7 @@ Change `1` key to `f1` if the device is Apple keyboard.
 
 | Name          | Required     | Description                                                                           |
 | ------------- | ------------ | ------------------------------------------------------------------------------------- |
-| `type`        | **Required** | `"device_if"` or `"device_unless"` or `"device_exists_if"` or `"device_exists_unless" |
+| `type`        | **Required** | `"device_if"` or `"device_unless"` or `"device_exists_if"` or `"device_exists_unless"`|
 | `identifiers` | **Required** | Target device definitions                                                             |
 | `description` | Optional     | A human-readable comment                                                              |
 


### PR DESCRIPTION
- add missing "`" on [this](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/conditions/device/) Karabiner-Elements Documentation page