### PR TITLE
add a note on how to only apply complex modifications to a particular keyboard

### DIFF
--- a/sites/karabiner-elements/content/en/docs/manual/configuration/add-your-own-complex-modifications/index.md
+++ b/sites/karabiner-elements/content/en/docs/manual/configuration/add-your-own-complex-modifications/index.md
@@ -24,9 +24,10 @@ When making changes, [Karabiner-EventViewer](/docs/manual/operation/eventviewer/
 
 {{< local-image src="images/own-rule-2@2x.png" >}}
 
-Note: you can target specific keyboard with complex modifications e.g.
 
-```
+{{% alert title="Tip" color="primary" %}}
+You can target specific keyboard with complex modifications e.g.
+```json
 {
     "description": "fix 2: left_command+3 -> 2, left_shift+3 -> @ (Internal keyboard only)",
     "manipulators": [
@@ -77,3 +78,4 @@ Note: you can target specific keyboard with complex modifications e.g.
     ]
 }
 ```
+{{% /alert %}}

--- a/sites/karabiner-elements/content/en/docs/manual/configuration/add-your-own-complex-modifications/index.md
+++ b/sites/karabiner-elements/content/en/docs/manual/configuration/add-your-own-complex-modifications/index.md
@@ -23,3 +23,57 @@ You can save by using the <kbd>command + s</kbd> shortcut as well.
 When making changes, [Karabiner-EventViewer](/docs/manual/operation/eventviewer/) and [Karabiner Configuration Reference Manual](/docs/json/) can be used to confirm the key names and how to write rules.
 
 {{< local-image src="images/own-rule-2@2x.png" >}}
+
+Note: you can target specific keyboard with complex modifications e.g.
+
+```
+{
+    "description": "fix 2: left_command+3 -> 2, left_shift+3 -> @ (Internal keyboard only)",
+    "manipulators": [
+        {
+            "conditions": [
+                {
+                    "identifiers": [{ "is_built_in_keyboard": true }],
+                    "type": "device_if"
+                }
+            ],
+            "from": {
+                "key_code": "3",
+                "modifiers": {
+                    "mandatory": ["left_command"],
+                    "optional": ["any"]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "2",
+                    "modifiers": []
+                }
+            ],
+            "type": "basic"
+        },
+        {
+            "conditions": [
+                {
+                    "identifiers": [{ "is_built_in_keyboard": true }],
+                    "type": "device_if"
+                }
+            ],
+            "from": {
+                "key_code": "3",
+                "modifiers": {
+                    "mandatory": ["left_shift"],
+                    "optional": ["any"]
+                }
+            },
+            "to": [
+                {
+                    "key_code": "2",
+                    "modifiers": ["left_shift"]
+                }
+            ],
+            "type": "basic"
+        }
+    ]
+}
+```


### PR DESCRIPTION
firstly, thank you so much for this! awesome project!

my 2 key broke and this was perfect to remap it! thanks.

I couldn't find on the documentation (https://karabiner-elements.pqrs.org/docs/manual/configuration/add-your-own-complex-modifications/) how to configure complex modifications for only 1 keyboard. I was able to figure it out with below. Adding that to the docs as well! 

I looks like you use hugo to render .md -> html, i think backticks should render ok with it but not super sure

```
{
    "description": "fix 2: left_command+3 -> 2, left_shift+3 -> @ (Internal keyboard only)",
    "manipulators": [
        {
            "conditions": [
                {
                    "identifiers": [{ "is_built_in_keyboard": true }],
                    "type": "device_if"
                }
            ],
            "from": {
                "key_code": "3",
                "modifiers": {
                    "mandatory": ["left_command"],
                    "optional": ["any"]
                }
            },
            "to": [
                {
                    "key_code": "2",
                    "modifiers": []
                }
            ],
            "type": "basic"
        },
        {
            "conditions": [
                {
                    "identifiers": [{ "is_built_in_keyboard": true }],
                    "type": "device_if"
                }
            ],
            "from": {
                "key_code": "3",
                "modifiers": {
                    "mandatory": ["left_shift"],
                    "optional": ["any"]
                }
            },
            "to": [
                {
                    "key_code": "2",
                    "modifiers": ["left_shift"]
                }
            ],
            "type": "basic"
        }
    ]
}
```